### PR TITLE
Fixed access token refreshing bottleneck

### DIFF
--- a/src/app/auth/jwt/jwt.service.ts
+++ b/src/app/auth/jwt/jwt.service.ts
@@ -6,8 +6,6 @@ import { EMPTY, Observable, throwError } from 'rxjs';
 import { Token } from '../token';
 import { RefreshTokenRequest } from '../refresh-token-request';
 import { jwtDecode } from 'jwt-decode';
-import { UserProfile } from '../../user/login/dtos/user-profile';
-import { decode } from 'punycode';
 
 
 @Injectable({

--- a/src/app/body-highlighter/volume.service.ts
+++ b/src/app/body-highlighter/volume.service.ts
@@ -44,8 +44,6 @@ export class VolumeService {
   }
 
   getWeeklyWorkoutDurationReport(startDate: string, endDate:string) {
-    console.log(startDate);
-    console.log(endDate);
     return this.http.get<any>(`${this.apiUrl}/weekly-workout-duration-report?startDate=` + startDate + `&endDate=` + endDate);
   }
 }

--- a/src/app/workout-duration-graph/workout-duration-graph.component.ts
+++ b/src/app/workout-duration-graph/workout-duration-graph.component.ts
@@ -30,7 +30,6 @@ export class WorkoutDurationGraphComponent {
     
         this.volumeService.getWeeklyWorkoutDurationReport(formatDate(startDate), formatDate(endDate)).subscribe({
           next: (response) => {
-            console.log(response)
             this.userSetsData = response.reverse();
     
             const labels = this.userSetsData.map(entry => entry.date.toString());


### PR DESCRIPTION
Now, when the token expires in the middle of a session, the user doesn't have to refresh the page to send the initial request again!